### PR TITLE
There's nothing that is specific with 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^5.6"
+        "php": "^5.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I suggest moving it to 5.5 instead of 5.6 due to no pre-requirements of 5.6